### PR TITLE
Fix code coverage GitHub Action in CI

### DIFF
--- a/template/.github/workflows/ci.yml
+++ b/template/.github/workflows/ci.yml
@@ -121,6 +121,7 @@ jobs:
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
         with:
+          version: '0.22.0'
           args: '--all-features --workspace --ignore-tests --out Lcov'
       - name: Upload to Coveralls
         # upload only if push


### PR DESCRIPTION
This PR fixes the code coverage GitHub Action this repository uses to upload coverage results to CodeCov.

The fix requires specifying a specific version as described in this issue: https://github.com/actions-rs/tarpaulin/issues/15

The issue was originally discovered and fixed here: https://github.com/lancelafontaine/spatular/pull/2